### PR TITLE
flip realtime timer return condition

### DIFF
--- a/labs/6-threads/code-threads/7-test-realtime-yield.c
+++ b/labs/6-threads/code-threads/7-test-realtime-yield.c
@@ -15,7 +15,7 @@ static void wait_usec(unsigned n) {
     demand(n < 100000, "unlikely large delay = %dusec!\n", n);
     unsigned start = timer_get_usec();
     while(1) {
-        if((timer_get_usec() - start) < n)
+        if((timer_get_usec() - start) > n)
             return;
         rpi_yield();
     }

--- a/labs/6-threads/code-threads/7-test-realtime-yield.c
+++ b/labs/6-threads/code-threads/7-test-realtime-yield.c
@@ -15,7 +15,7 @@ static void wait_usec(unsigned n) {
     demand(n < 100000, "unlikely large delay = %dusec!\n", n);
     unsigned start = timer_get_usec();
     while(1) {
-        if((timer_get_usec() - start) > n)
+        if((timer_get_usec() - start) >= n)
             return;
         rpi_yield();
     }


### PR DESCRIPTION
We only want to return once `n` usec has passed, so we only want to return once `(time_elapsed) >= n`. (currently just returns immediately)