### PR TITLE
`strncmp`: Don't Compare Past the Null Terminator

### DIFF
--- a/libpi/libc/strncmp.c
+++ b/libpi/libc/strncmp.c
@@ -1,11 +1,22 @@
 #include "rpi.h"
 
-// https://clc-wiki.net/wiki/strncmp#Implementation
-int strncmp(const char* _s1, const char* _s2, size_t n) {
-    const unsigned char *s1 = (void*)_s1, *s2 = (void*)_s2;
-    while(n--) {
-        if(*s1++!=*s2++)
-            return s1[-1] - s2[-1];
+// Implementation taken from newlib
+// See: newlib/libc/string/strncmp.c
+int strncmp(const char* s1, const char* s2, size_t n) {
+
+    // Edge case: We don't want to do any dereferencing if the buffers aren't
+    // valid
+    if (n == 0)
+        return 0;
+
+    while (n-- != 0 && *s1 == *s2) {
+        // Don't increment the pointers past the end of the array
+        // Don't increment the pointers past the null-terminator either
+        if (n == 0 || *s1 == '\0')
+            break;
+        s1++;
+        s2++;
     }
-    return 0;
+
+    return (*(unsigned char *) s1) - (*(unsigned char *) s2);
 }


### PR DESCRIPTION
The previous implementation of `strncmp` did not break out of the loop upon encountering a null terminator. Instead, it would compare the entire buffer up to the first different element. This commit fixes that.

I formally verified this commit using `cbmc`. Specifically, I checked that this implementation of `strncmp` agrees with my Linux system's implementation (up to a certain depth). I also checked that the previous implementation did not agree. I ran `cbmc` as
```bash
$ cbmc --bounds-check --pointer-check --unwinding-assertions --unwind 513 strncmp-test.c
```
My testbench is [strncmp-test.c](https://github.com/dddrrreee/cs140e-24win/files/14621799/strncmp-test.c.txt), with `my_strncmp` commented out.